### PR TITLE
token expired

### DIFF
--- a/src/components/containers/HandleErrors/HandleErrors.js
+++ b/src/components/containers/HandleErrors/HandleErrors.js
@@ -33,9 +33,12 @@ export class HandleErrors extends Component {
     const requestErrorStatus = requestError.payload.status;
     switch (true) {
       case (this.isTokenExpired(requestError)):
-        document.cookie = 'JSESSIONID=; expires=Thu, 01-Jan-70 00:00:01 GMT;';
-        window.location.replace('/');
-        return null;
+        return {
+          eventOk: this.redirectIndexPage,
+          eventHide: this.redirectIndexPage,
+          textButton: 'Login Again',
+          textMessage: 'Your session has expired.  Click the button to log in again',
+        };
       case ('application/rss+xml' === get(requestError, 'payload.request.responseType', '')):
         return {
           eventOk: this.closeModal,
@@ -84,29 +87,31 @@ export class HandleErrors extends Component {
     location.reload()
   };
 
+  redirectIndexPage = () => {
+    document.cookie = 'JSESSIONID=; expires=Thu, 01-Jan-70 00:00:01 GMT;';
+    window.location.replace('/');
+  };
+
   render() {
     const { isOpenModal } = this.state;
     const config = this.getErrorConfig();
-    if (config) {
-      return (
-        <div>
-          {isOpenModal &&
-            <ConfirmationModal
-              title={'Connection Error'}
-              onOk={config.eventOk}
-              onHide={config.eventHide}
-              onCancel={config.eventCancel}
-              isShow
-              textOkButton={config.textButton}
-              isShowOkButton
-              isShowCancelButton={config.isShowCancelButton}
-            >
-            <span>{config.textMessage}</span>
-          </ConfirmationModal> }
-        </div>
-        )
-    }
-    return null;
+    return (
+      <div>
+        {isOpenModal &&
+        <ConfirmationModal
+          title={'Connection Error'}
+          onOk={config.eventOk}
+          onHide={config.eventHide}
+          onCancel={config.eventCancel}
+          isShow
+          textOkButton={config.textButton}
+          isShowOkButton
+          isShowCancelButton={config.isShowCancelButton}
+        >
+          <span>{config.textMessage}</span>
+        </ConfirmationModal> }
+      </div>
+    )
   }
 }
 

--- a/src/components/containers/HandleErrors/HandleErrors.js
+++ b/src/components/containers/HandleErrors/HandleErrors.js
@@ -23,9 +23,9 @@ export class HandleErrors extends Component {
   }
 
   isTokenExpired = (requestError) => {
-      const requestErrorStatus = requestError.payload.status;
-      const errorMessage = get(requestError, 'payload.xhr.response.error', '');
-      return (requestErrorStatus === 400 && errorMessage === 'Invalid JWT: Error: Token expired') || requestErrorStatus === 403;
+    const requestErrorStatus = requestError.payload.status;
+    const errorMessage = get(requestError, 'payload.xhr.response.error', '');
+    return (requestErrorStatus === 400 && errorMessage === 'Invalid JWT: Error: Token expired') || requestErrorStatus === 403;
   };
 
   getErrorConfig = () => {

--- a/src/components/pages/Allergies/ducks/fetch-patient-allergies.duck.js
+++ b/src/components/pages/Allergies/ducks/fetch-patient-allergies.duck.js
@@ -45,7 +45,6 @@ export const fetchPatientAllergiesSynopsisEpic = (action$, store) =>
           userId: payload.userId,
           allergies: get(response, 'synopsis', []),
         }))
-        .catch(error => Observable.of(handleErrors(error)))
     );
 
 export const fetchPatientAllergiesUpdateEpic = (action$, store) =>

--- a/src/components/pages/Contacts/ducks/fetch-patient-contacts.duck.js
+++ b/src/components/pages/Contacts/ducks/fetch-patient-contacts.duck.js
@@ -45,7 +45,6 @@ export const fetchPatientContactsSynopsisEpic = (action$, store) =>
           userId: payload.userId,
           contacts: get(response, 'synopsis', []),
         }))
-        .catch(error => Observable.of(handleErrors(error)))
     );
 
 export const fetchPatientContactsUpdateEpic = (action$, store) =>

--- a/src/components/pages/Medications/ducks/fetch-patient-medications.duck.js
+++ b/src/components/pages/Medications/ducks/fetch-patient-medications.duck.js
@@ -46,7 +46,6 @@ export const fetchPatientMedicationsSynopsisEpic = (action$, store) =>
           userId: payload.userId,
           medications: get(response, 'synopsis', []),
         }))
-        .catch(error => Observable.of(handleErrors(error)))
     );
 
 export const fetchPatientMedicationsUpdateEpic = (action$, store) =>

--- a/src/components/pages/ProblemsDiagnosis/ducks/fetch-patient-diagnoses.duck.js
+++ b/src/components/pages/ProblemsDiagnosis/ducks/fetch-patient-diagnoses.duck.js
@@ -45,7 +45,6 @@ export const fetchPatientDiagnosesSynopsisEpic = (action$, store) =>
           userId: payload.userId,
           diagnoses: get(response, 'synopsis', []),
         }))
-        .catch(error => Observable.of(handleErrors(error)))
     );
 
 export const fetchPatientDiagnosesUpdateEpic = (action$, store) =>

--- a/src/components/pages/TopThreeThings/ducks/fetch-patient-top-three-things.duck.js
+++ b/src/components/pages/TopThreeThings/ducks/fetch-patient-top-three-things.duck.js
@@ -45,7 +45,6 @@ export const fetchPatientTopThreeThingsSynopsisEpic = (action$, store) =>
           userId: payload.userId,
           topThreeThings: get(response, 'synopsis', []),
         }))
-        .catch(error => Observable.of(fetchPatientTopThreeThingsFailure(error)))
     );
 
 export const fetchPatientTopThreeThingsUpdateEpic = (action$, store) =>

--- a/src/components/pages/Vaccinations/ducks/fetch-patient-vaccinations.duck.js
+++ b/src/components/pages/Vaccinations/ducks/fetch-patient-vaccinations.duck.js
@@ -45,7 +45,6 @@ export const fetchPatientVaccinationsSynopsisEpic = (action$, store) =>
           userId: payload.userId,
           vaccinations: get(response, 'synopsis', []),
         }))
-        .catch(error => Observable.of(handleErrors(error)))
     );
 
 export const fetchPatientVaccinationsUpdateEpic = (action$, store) =>

--- a/src/ducks/fetch-patient-demographics.duck.js
+++ b/src/ducks/fetch-patient-demographics.duck.js
@@ -23,7 +23,6 @@ export const fetchPatientDemographicsEpic = (action$, store) =>
           userId: payload.userId,
           demographics: get(response, 'demographics', {}),
         }))
-        .catch(error => Observable.of(fetchPatientDemographicsFailure(error)))
   );
 
 export default function reducer(patientsDemographics = {}, action) {

--- a/src/themes.config.js
+++ b/src/themes.config.js
@@ -59,4 +59,4 @@ const leedsPHRThemeConfigs = {
 // - You should set 'true' only for:
 // - patients-summary, diagnoses, medications, allergies, contacts, vaccinations, topThreeThings
 
-export const themeConfigs = leedsPHRThemeConfigs;
+export const themeConfigs = mainThemeConfigs;

--- a/src/themes.config.js
+++ b/src/themes.config.js
@@ -59,4 +59,4 @@ const leedsPHRThemeConfigs = {
 // - You should set 'true' only for:
 // - patients-summary, diagnoses, medications, allergies, contacts, vaccinations, topThreeThings
 
-export const themeConfigs = mainThemeConfigs;
+export const themeConfigs = leedsPHRThemeConfigs;


### PR DESCRIPTION
Rob Tweed: My recommendation is that if the session has timed out, the user must be forced to log in again.  The simplest way to do this, without significant further development at the front and back-ends, is for PulseTile to delete the JSESSIONID token and reload the index.html page.  That will force the user to log in and start again from the top
