### PR TITLE
user profile link

### DIFF
--- a/src/components/containers/UserPanel/UserAccountPanel.js
+++ b/src/components/containers/UserPanel/UserAccountPanel.js
@@ -57,9 +57,11 @@ export default class UserAccountPanel extends PureComponent {
         <div className="user-profile-info">
           <div
             className="user-profile-info__item name"
-            onClick={() =>{
-              this.context.router.history.push(clientUrls.USER_PROFILE);
-              onClick('')
+            onClick={() => {
+                if (themeConfigs.isShowUserProfileSettings) {
+                    this.context.router.history.push(clientUrls.USER_PROFILE);
+                    onClick('');
+                }
             }}
           >{user.given_name} {user.family_name}</div>
           <div className="user-profile-info__descr">

--- a/src/components/containers/UserPanel/UserAccountPanel.js
+++ b/src/components/containers/UserPanel/UserAccountPanel.js
@@ -58,7 +58,7 @@ export default class UserAccountPanel extends PureComponent {
           <div
             className="user-profile-info__item name"
             onClick={() => {
-                if (themeConfigs.isShowUserProfileSettings) {
+                if (themeConfigs.isShowUserAccountPage) {
                     this.context.router.history.push(clientUrls.USER_PROFILE);
                     onClick('');
                 }


### PR DESCRIPTION
For the issue: https://github.com/LeedsCC/Helm-PHR-Project/issues/100

The reason is that user profile page is unavailable in Helm version. When user click on name in User Panel, it should redirect him to the /profile page. But if this page is unavailable, user will be redirected to the homepage (with charts). 

I added the condition, that if user profile page is unavailable (by theme settings), user name isn't clickable.